### PR TITLE
Direct notebook links

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,8 +16,10 @@ class Redirector(tornado.web.RequestHandler):
     """
     Redirect calls to the Binder API depending on status
     """
-    def get(self, app_id):
+    def get(self, org, repo, location=None):
 
+        # get locations
+        app_id = org + "/" + repo
         baseurl = self.request.protocol + "://" + self.request.host
         endpoint = 'http://' + options.api + ':8080/apps/'
         
@@ -52,7 +54,12 @@ class Redirector(tornado.web.RequestHandler):
                                 redirectblob = r.json()
                                 if 'redirect_url' in redirectblob:
                                     url = redirectblob['redirect_url']
-                                    self.redirect(url)
+                                    if location is not None and location != '':
+                                        logging.debug('redirecting to: %s' % url + "/" + location)
+                                        self.redirect(url + "/notebooks/" + location)
+                                    else:
+                                        logging.debug('redirecting to: %s' % url)
+                                        self.redirect(url)
                                 else:
                                     self.redirect(baseurl + '/status/unknown.html')
                             except Exception as e:
@@ -99,7 +106,8 @@ settings = {
 }
 
 application = tornado.web.Application([
-    (r"/repo/(?P<app_id>.*)", Redirector),
+    (r"/repo/(?P<org>[^\/]+)/(?P<repo>[^\/]+)/(?P<location>.*)", Redirector),
+    (r"/repo/(?P<org>[^\/]+)/(?P<repo>[^\/]+)", Redirector),
     (r"/(.*)", CustomStatic, {'path': root + "/static/", "default_filename": "index.html"})
 ], autoreload=True, **settings)
 

--- a/app.py
+++ b/app.py
@@ -18,6 +18,10 @@ class Redirector(tornado.web.RequestHandler):
     """
     def get(self, org, repo, location=None):
 
+        # strip trailing /
+        if repo[-1] == '/':
+            repo = repo[:-1]
+
         # get locations
         app_id = org + "/" + repo
         baseurl = self.request.protocol + "://" + self.request.host

--- a/app.py
+++ b/app.py
@@ -59,7 +59,7 @@ class Redirector(tornado.web.RequestHandler):
                                 if 'redirect_url' in redirectblob:
                                     url = redirectblob['redirect_url']
                                     if location is not None and location != '':
-                                        logging.debug('redirecting to: %s' % url + "/" + location)
+                                        logging.debug('redirecting to: %s' % url + "/notebooks/" + location)
                                         self.redirect(url + "/notebooks/" + location)
                                     else:
                                         logging.debug('redirecting to: %s' % url)


### PR DESCRIPTION
This PR adds support for direct linking to notebooks, as requested in #9 

Implementation details:
- routes now support an optional location parameter as anything following user/repo
- the redirector posts to the Binder API, gets a URL for a deployment, and then appends the location (if there is one) before redirecting

Examples of the new behavior (tested locally, examples relevant to @mathisonian):

`http://localhost:5000/repo/lightning-viz/lightning-example-notebooks/index.ipynb`

-> the `index.ipynb` notebook

`http://localhost:5000/repo/lightning-viz/lightning-example-notebooks`
`http://localhost:5000/repo/lightning-viz/lightning-example-notebooks/`

-> the `index.ipynb` notebook (same default behavior as before)

`http://localhost:5000/repo/lightning-viz/lightning-example-notebooks/plots/`
`http://localhost:5000/repo/lightning-viz/lightning-example-notebooks/plots`

-> the `plots` folder

`http://localhost:5000/repo/lightning-viz/lightning-example-notebooks/plots/scatter.ipynb`

-> the `plots/scatter.ipynb` notebook

Seem reasonable?
