### PR TITLE
Repo checking

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -78,7 +78,7 @@ a:hover {
 	display: none;
 }
 
-#failed, #norepo, #building, #timeout {
+#failed, #norepo, #building, #timeout, #invalid {
 	display: none;
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -131,6 +131,16 @@
 		</div>
 	</div>
 
+	<div class='row' id='invalid' style='margin-top:50px'>
+		<div class='column-2'></div>
+		<div class='box column-5'>
+			<h2 class='failed'><span id='repo-error'></span>, please double check the repo and try again.</h2>
+		</div>
+		<div class='column-3'>
+			<p class='sidebar'>Make sure the contents of your repository match your build specification.</p>
+		</div>
+	</div>
+
 	<div class='row' id='building' style='margin-top:50px'>
 		<div class='column-2'></div>
 		<div class='box column-5'>
@@ -159,14 +169,6 @@
 		<p style='font-size: 20px'>check the system <a class='grayed' href='status'>status</a></p>
 	</div>
 
-	<div id="modal" class="dialog">
-		<div>
-			<a id="close" class="close">X</a>
-			<h2>Cannot build Binder</h2>
-			<p>GitHub repo not specified</p>
-		</div>
-	</div>
-
 </body>
 
 </html>
@@ -191,6 +193,7 @@ function clearMessages() {
 	$('#badge').fadeOut(100)
 	$('#failed').fadeOut(100)
 	$('#norepo').fadeOut(100)
+	$('#invalid').fadeOut(100)
 	$('#building').fadeOut(100)
 	$('#timeout').fadeOut(100)
 }
@@ -312,17 +315,19 @@ $("#submit").click(function( event ) {
  		$.ajax(
 
  			{
- 				method: "GET",
- 				url: "https://api.github.com/repos/" + repo,
+ 				method: "POST",
+ 				url: "/submit/",
+ 				dataType: 'json',
+ 				timeout: 4000,
+ 				data: {submission: JSON.stringify(payload), repo: repo},
 
- 				// if the repo exists, proceed to check status
+ 				// check the status of the repo
  				success: function(data) {
- 					getStatus()
- 				},
-
- 				// if the repo doesn't exist, throw an error
- 				error: function(err) {
- 					norepoMessage()
+ 					if (data.success == true) {
+ 						getStatus()
+ 					} else {
+ 						invalidMessage(data.msg)
+ 					}
  				},
 
  				beforeSend: function() {
@@ -428,6 +433,15 @@ $("#submit").click(function( event ) {
 		$('#norepo').fadeIn(700)
 		$('html, body').animate({
 	    	scrollTop: $("#norepo").offset().top
+		}, 700);
+ 	}
+
+ 	function invalidMessage(msg) {
+ 		$('#repo-error').text(msg);
+ 		$('#spinner').fadeOut(100);
+ 		$('#invalid').fadeIn(700)
+ 		$('html, body').animate({
+	    	scrollTop: $("#invalid").offset().top
 		}, 700);
  	}
 

--- a/static/index.html
+++ b/static/index.html
@@ -125,23 +125,13 @@
 		</div>
 	</div>
 
-	<div class='row' id='norepo' style='margin-top:50px'>
-		<div class='column-2'></div>
-		<div class='box column-5'>
-			<h2 class='failed'>Oops, that GitHub repo does not exist. Double check the repo name and try again.</h2>
-		</div>
-		<div class='column-3'>
-			<p class='sidebar'>The name you entered was <span id='norepo-name' style="color: rgb(150,150,150)"></span>, make sure that's a valid repository.</p>
-		</div>
-	</div>
-
 	<div class='row' id='invalid' style='margin-top:50px'>
 		<div class='column-2'></div>
 		<div class='box column-5'>
 			<h2 class='failed'><span id='repo-error'></span>, double check the repo and try again.</h2>
 		</div>
 		<div class='column-3'>
-			<p class='sidebar'>The repo you entered was <span id='norepo-name' style="color: rgb(150,150,150)"></span>, make sure that's correct and that the contents match your build specification.</p>
+			<p class='sidebar'>The repo you entered was <a id='norepo-name' class='grayed'></a>, make sure that's correct and that the contents match your build specification.</p>
 		</div>
 	</div>
 
@@ -319,30 +309,38 @@ $("#submit").click(function( event ) {
  		// strip .git (if pasted from github)
  		repo = repo.replace('.git', '')
 
- 		$.ajax(
+ 		if ((repo.indexOf('/') < 0) | (repo.indexOf(' ') > -1)) {
+ 			
+ 			invalidMessage('Oops, that repo name appears badly formatted')
 
- 			{
- 				method: "POST",
- 				url: "/submit/",
- 				dataType: 'json',
- 				timeout: 4000,
- 				data: {submission: JSON.stringify(payload), repo: repo},
+ 		} else {
 
- 				// check the status of the repo
- 				success: function(data) {
- 					if (data.success == true) {
- 						getStatus()
- 					} else {
- 						invalidMessage(data.msg)
- 					}
- 				},
+	 		$.ajax(
 
- 				beforeSend: function() {
- 					$('#spinner').fadeIn(300);
- 				}
- 			}
+	 			{
+	 				method: "POST",
+	 				url: "/validate/",
+	 				dataType: 'json',
+	 				timeout: 4000,
+	 				data: {submission: JSON.stringify(payload), repo: repo},
 
- 			)
+	 				// check the status of the repo
+	 				success: function(data) {
+	 					if (data.success == true) {
+	 						getStatus()
+	 					} else {
+	 						invalidMessage(data.msg)
+	 					}
+	 				},
+
+	 				beforeSend: function() {
+	 					$('#spinner').fadeIn(300);
+	 				}
+	 			}
+
+	 			)
+
+ 		}
  	}
 
  	function getStatus() {
@@ -437,7 +435,9 @@ $("#submit").click(function( event ) {
 
  	function invalidMessage(msg) {
  		$('#repo-error').text(msg);
- 		$('#norepo-name').text(repo);
+ 		el = $('#norepo-name')
+ 		el.text(repo);
+ 		el.attr('href', 'https://github.com/' + repo)
  		$('#spinner').fadeOut(100);
  		$('#invalid').fadeIn(700)
  		$('html, body').animate({

--- a/static/index.html
+++ b/static/index.html
@@ -141,7 +141,7 @@
 			<h2 class='failed'><span id='repo-error'></span>, double check the repo and try again.</h2>
 		</div>
 		<div class='column-3'>
-			<p class='sidebar'>Make sure the contents of your repository match your build specification.</p>
+			<p class='sidebar'>The repo you entered was <span id='norepo-name' style="color: rgb(150,150,150)"></span>, make sure that's correct and that the contents match your build specification.</p>
 		</div>
 	</div>
 
@@ -435,17 +435,9 @@ $("#submit").click(function( event ) {
 		}, 700);
  	}
 
- 	function norepoMessage() {
- 		$('#spinner').fadeOut(100);
- 		$('#norepo-name').text(repo);
-		$('#norepo').fadeIn(700);
-		$('html, body').animate({
-	    	scrollTop: $("#norepo").offset().top
-		}, 700);
- 	}
-
  	function invalidMessage(msg) {
  		$('#repo-error').text(msg);
+ 		$('#norepo-name').text(repo);
  		$('#spinner').fadeOut(100);
  		$('#invalid').fadeIn(700)
  		$('html, body').animate({


### PR DESCRIPTION
This PR addresses https://github.com/binder-project/binder/issues/5, by adding repo content checking to the web app. The checking is server-side with authentication, using the Python client to GitHub's API. I've also added some simple repo validation on the front end for typos / formatting errors.

As our dependency specifications options are currently rather simple, the check is also rather simple (i.e. if you asked for `requirements.txt`, do you have `requirements.txt`). Users will get messages like:

![screen shot 2015-09-15 at 1 58 52 pm](https://cloud.githubusercontent.com/assets/3387500/9885628/27484d38-5bb4-11e5-83d4-ba095abbe060.png)

One thing we're NOT doing is making sure that if your repo has a particular resource, you're requesting to use it. For example, if you ask to build with `None` but actually have a `requirements.txt` in your repo, that's "ok". Unless anyone feels we need that, I would err towards letting uses do what they want.
